### PR TITLE
Allow Source Extractor command to be sex, or sextractor.

### DIFF
--- a/pp_extract.py
+++ b/pp_extract.py
@@ -54,6 +54,19 @@ extractQueue = Queue.Queue(2000)
 threadLock = threading.Lock()   
 
 
+# Determine the Source Extractor executable name: sex or sextractor.
+for cmd in ['sex', 'sextractor']:
+    try:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        del p
+        break
+    except FileNotFoundError:
+        continue
+else:
+    raise FileNotFoundError('Source Extractor command not found.')
+sextractor_cmd = cmd
+del cmd
+
 ##### extractor class definition
 
 class extractor(threading.Thread):
@@ -112,8 +125,9 @@ class extractor(threading.Thread):
                     optionstring += ' -SATUR_LEVEL 1000000'
                     optionstring += ' -SATUR_KEY NOPE'
 
-            commandline = 'sex -c %s %s %s' % \
-                          (self.param['obsparam']['sex-config-file'], 
+            commandline = '%s -c %s %s %s' % \
+                          (sextractor_cmd,
+                           self.param['obsparam']['sex-config-file'], 
                            optionstring, filename)
 
             logging.info('call Source Extractor as: %s' % commandline)


### PR DESCRIPTION
Hi Michael,

The Source Extractor command on my system (Ubuntu) is `sextractor` rather than `sex` as built into the code.  I added a test to the top of pp_extract to determine which command to use through trial and error.  A FileNotFoundError is raised if neither command works.  This change seems to work for me, but I am using python3, so I recommend testing it out first.

- msk