### PR TITLE
Use OSError, rather than python3's FileNotFoundError.

### DIFF
--- a/pp_extract.py
+++ b/pp_extract.py
@@ -60,7 +60,7 @@ for cmd in ['sex', 'sextractor']:
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         del p
         break
-    except FileNotFoundError:
+    except OSError:
         continue
 else:
     raise FileNotFoundError('Source Extractor command not found.')


### PR DESCRIPTION
Sorry, I had used `FileNotFoundError` when catching the exception for the sextractor command test.  To work for both 2.7 and 3.x, it should be `OSError`.  This will fix it.

- msk