### PR TITLE
improve kband error

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -399,7 +399,8 @@ class catalog(object):
             # photometric catalog
             vquery = Vizier(columns=['2MASS', 'RAJ2000', 'DEJ2000', 'errMaj', 
                                      'errMin', 'errPA', 'Jmag', 'e_Jmag',
-                                     'Hmag', 'e_Hmag', 'Kmag', 'e_Kmag'],
+                                     'Hmag', 'e_Hmag', 'Kmag', 'e_Kmag',
+                                     'Qflg', 'Rflg'],
                             column_filters={"Jmag":
                                             ("<%f" % max_mag)},
                             row_limit = max_sources)
@@ -413,6 +414,14 @@ class catalog(object):
                     print('no data available from %s' % self.catalogname)
                 logging.error('no data available from %s' % self.catalogname)
                 return 0
+
+            # filter columns to only have really good detections
+            # see the Vizier webpage for a description of what the flags mean
+            Qflags = set('ABC') # only A, B, or C flagged detections
+            qmask = [True if not set(item).difference(Qflags) else False
+                        for item in self.data['Qflg']]
+            # filter columns to only have really good detections
+            self.data = self.data[qmask]
 
             ### rename column names using PP conventions
             self.data.rename_column('_2MASS', 'ident')


### PR DESCRIPTION
Add some quality flags to improve the photometry in the 2MASS bands. 

Before: 

> boada$ pp_calibrate -cat 2MASS test.fits 
(16547, 25) (sources, columns) read from test.fits
query Vizier for 2MASS at xxx.xxx/ +xx.xxx in a 0.99 deg radius 2060 sources retrieved.
2060 sources downloaded from 2MASS
1133 sources with accurate magnitudes in K band
zeropoint for test.ldac: 26.028+-0.170 (134/265 reference stars)
write calibrated data into database files

After:

> boada$ pp_calibrate -cat 2MASS test.fits 
(16547, 25) (sources, columns) read from test.fits
query Vizier for 2MASS at xxx.xxx/ +xx.xxx in a 0.99 deg radius 1280 sources retrieved.
1280 sources downloaded from 2MASS
952 sources with accurate magnitudes in K band
zeropoint for test.ldac: 26.024+-0.079 (115/226 reference stars)
write calibrated data into database files

From the 2MASS documentation:

>  Three character flag, one character per band [JHK], that provides a summary of the net quality of the default photometry in each band, as derived from the Read Flag (Rflg), measurement uncertainties ([jhk]cmsig), scan signal-to-noise ratios ([jhk]snr), frame-detection statistics (Ndet), and profile-fit reduced chi-squared values ([jhk]psfchi).

And: 

> A = Detections in any brightness regime where valid measurements were made (Rflg="1","2" or "3") with [jhk]snr>10 AND [jhk]cmsig<0.10857.

> B = Detections in any brightness regime where valid measurements were made (Rflg="1","2" or "3") with [jhk]snr>7 AND [jhk]cmsig<0.15510.

> C = Detections in any brightness regime where valid measurements were made (Rflg="1","2" or "3") with [jhk]snr>5 AND [jhk]cmsig<0.21714.

Sure it reduces the number of sources that we have to choose from, but it also reduces the zeropoint error by a factor of 2. 




