### PR TITLE
2MASS VEGA -> AB

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -423,6 +423,12 @@ class catalog(object):
             # filter columns to only have really good detections
             self.data = self.data[qmask]
 
+            # By default, 2MASS magnitudes are VEGA magnitudes
+            # Convert to AB mags see Blanton et al., AJ, 2005, Eqs. (5)
+            self.data['Jmag'] += 0.91
+            self.data['Hmag'] += 1.39
+            self.data['Jmag'] += 1.85
+
             ### rename column names using PP conventions
             self.data.rename_column('_2MASS', 'ident')
             self.data.rename_column('RAJ2000', 'ra.deg')            

--- a/catalog.py
+++ b/catalog.py
@@ -427,7 +427,7 @@ class catalog(object):
             # Convert to AB mags see Blanton et al., AJ, 2005, Eqs. (5)
             self.data['Jmag'] += 0.91
             self.data['Hmag'] += 1.39
-            self.data['Jmag'] += 1.85
+            self.data['Kmag'] += 1.85
 
             ### rename column names using PP conventions
             self.data.rename_column('_2MASS', 'ident')


### PR DESCRIPTION
Currently, the pipeline downloads 2MASS magnitudes from VIZIER. These magnitudes are VEGA magnitudes. The rest of the pipeline (i.e., SDSS) works in AB magnitudes. This converts the VEGA to AB mags.  