### PR TITLE
Fixed issue taking exactly 6 arguments (5 given)

### DIFF
--- a/pp_run.py
+++ b/pp_run.py
@@ -403,7 +403,7 @@ if __name__ == '__main__':
                 os.chdir(root)
 
                 run_the_pipeline(filenames, man_targetname, man_filtername,
-                                 fixed_aprad, source_tolerance)
+                                 fixed_aprad, source_tolerance, solar)
                 os.chdir(_masterroot_directory)
             else:
                 print('\n NOTHING TO DO IN %s' % root)


### PR DESCRIPTION
Running 'pp_run all' fails with error

File "photometrypipeline/pp_run", line 406, in <module>
fixed_aprad, source_tolerance)
TypeError: run_the_pipeline() takes exactly 6 arguments (5 given)

because solar argument is missing.