### PR TITLE
change shebang to python3

### DIFF
--- a/pp_calibrate.py
+++ b/pp_calibrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_CALIBRATE - match image databases against photometry catalogs
                    and derive magnitude zeropoint

--- a/pp_combine.py
+++ b/pp_combine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_COMBINE - combine frames based on wcs 
     v1.0: 2017-10-03, mommermiscience@gmail.com

--- a/pp_distill.py
+++ b/pp_distill.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_DISTILL - distill calibrated image databases into one database
                  of select moving or fixed sources

--- a/pp_extract.py
+++ b/pp_extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_EXTRACT - identify field sources using Source Extractor with
     multi-threading capabilities

--- a/pp_manident.py
+++ b/pp_manident.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ MANIDENT - manual target identification tool for the Photometry Pipeline
 

--- a/pp_photometry.py
+++ b/pp_photometry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_PHOTOMETRY - run curve-of-growth analysis on image files,
                     identify optimum aperture radius, and redo photometry

--- a/pp_prepare.py
+++ b/pp_prepare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_PREPARE - prepare fits images for photometry pipeline
     v1.0: 2016-02-27, mommermiscience@gmail.com

--- a/pp_register.py
+++ b/pp_register.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_REGISTER - wcs register frames
     v1.0: 2015-12-30, mommermiscience@gmail.com

--- a/pp_stackedphotometry.py
+++ b/pp_stackedphotometry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PP_STACKEDPHOTOMETRY - wrapper to perform photometry on stacked images
     v1.0: 2017-10-19, mommermiscience@gmail.com

--- a/pptool_mpcreport.py
+++ b/pptool_mpcreport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PPTOOL_MPCREPORT - produce a file for submission of asteroid astrometry
                        to the Minor Planet center

--- a/pptool_psfsub.py
+++ b/pptool_psfsub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ PPTOOL_PSFSUB - PSF subtraction tool
     v1.0: 2017-12-10, mommermiscience@gmail.com


### PR DESCRIPTION
If legacy Python isn't going to be supported any more, then the shebangs at the top of the files should be changed to python3 instead of python. On systems with both legacy python and python3 installed 'python' can often refer to python2 and 'python3' can refer to python3.

In addition, there is a lot of code that still checks for python2/3 compatibility. That code could be removed to further push the transition to python3. Maybe I'll submit a PR for those changes later.
