### PR TITLE
Correct typo in skimage diagnostics

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -44,7 +44,7 @@ try:
     from skimage.transform import resize
 except ImportError:
     print('Module skimage not found. Please install with: pip install '
-          'scikit-kimage')
+          'scikit-image')
     sys.exit()
 
 # pipeline-specific modules


### PR DESCRIPTION
Hi,

While trying out this cool software I spotted a typo (?) in the skimage install command suggested in diagnostics.py; the module is in pip as scikit-image rather than scikit-kimage. Here's a quick fix.