### PR TITLE
NOTALFOSC parameter updates

### DIFF
--- a/setup/telescopes.py
+++ b/setup/telescopes.py
@@ -4057,7 +4057,9 @@ notalfosc_param = {
     # pp_prepare
     'object': 'OBJECT',  # object name keyword
     'filter': 'ALFLTNM',  # filter keyword
-    'filter_translations': {'Open': None},
+    'filter_translations': {'Open': None, 'U_Bes 362_60': 'U',
+                            'B_Bes 440_100': 'B', 'V_Bes 530_80': 'V',
+                            'R_Bes 650_130': 'R', 'i_int 797_157': 'I'},
     # filtername translation dictionary
     'exptime': 'EXPTIME',  # exposure time keyword (s)
     'airmass': 'AIRMASS',  # airmass keyword

--- a/setup/telescopes.py
+++ b/setup/telescopes.py
@@ -4030,7 +4030,7 @@ intwfc_param = {
 notalfosc_param = {
     'telescope_instrument': 'NOT/ALFOSC',  # telescope/instrument name
     'telescope_keyword': 'NOTALFOSC',      # telescope/instrument keyword
-    'observatory_code': 'Z18',         # MPC observatory code
+    'observatory_code': 'Z23',         # MPC observatory code
     'secpix': (0.2138, 0.2138),  # pixel size (arcsec)
     # before binning
     'ext_coeff': 0.05,          # typical extinction coefficient


### PR DESCRIPTION
Hi,
This PR adds correct filter translations for the UBVRI filters for the NOT. In addition, the (previously incorrect) observatory code is fixed.

I also note that ALFOSC/FASU has multiple filter wheels, each with its own individual keyword. The UBVRI filters are always in ALFLTNM (which telescopes.py currently checks) but e.g. the SDSS filters are usually found in FAFLTNM. This PR doesn't do anything about that as I'm unsure on how you'd want to handle that properly.