### PR TITLE
Correct disp format in catalog.py

### DIFF
--- a/catalog.py
+++ b/catalog.py
@@ -828,9 +828,9 @@ class catalog(object):
                       'e_ra_deg': '1E',
                       'e_dec_deg': '1E',
                       'mag': '1E'}
-        disp_dic = {'ra_deg': 'E15', 'dec_deg': 'E15',
-                    'e_ra_deg': 'E12',
-                    'e_dec_deg': 'E12',
+        disp_dic = {'ra_deg': 'F13.8', 'dec_deg': 'F13.8',
+                    'e_ra_deg': 'F13.8',
+                    'e_dec_deg': 'F13.8',
                     'mag': 'F8.4'}
         unit_dic = {'ra_deg': 'deg', 'dec_deg': 'deg',
                     'e_ra_deg': 'deg',


### PR DESCRIPTION
This fixes bug #45 by using valid values for disp_dic in catalog.py.

I think that these values have always been invalid, but astropy has not validated them before release 4.0.1 (see https://github.com/astropy/astropy/pull/9978 ) so it hasn't raised any errors in the past and we've been feeding 'garbage' values into it until now. Considering that things have worked in the past even with invalid values here, maybe it's not actually too important..?

I don't know if the format in this commit makes much sense (it probably doesn't?) - I more or less arbitrarily copied it from the disp format used for OBSDATE. Still, astropy accepts it and thus it fixes the crash.